### PR TITLE
Add pytest tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install pytest
+      - name: Run tests
+        run: pytest -v
+

--- a/README.md
+++ b/README.md
@@ -24,3 +24,14 @@ Use a valid market symbol (e.g. `ETH-USD-PERP`). You can retrieve the
 available markets via `paradex_cli markets`.
 
 Pass `--help` to see all options.
+
+### Testing
+
+Run unit tests locally with `pytest`:
+
+```bash
+pytest -v
+```
+
+Tests are also executed automatically on GitHub via the workflow in
+`.github/workflows/ci.yml`.

--- a/market_utils.py
+++ b/market_utils.py
@@ -1,0 +1,21 @@
+from decimal import Decimal
+
+
+def check_inversion(order_book: dict) -> Decimal:
+    """Return profit if best bid is higher than best ask.
+
+    Profit is calculated as the difference between the best bid and best ask
+    prices. If there is no inversion return ``Decimal('0')``.
+    """
+    bids = order_book.get("bids", [])
+    asks = order_book.get("asks", [])
+    if not bids or not asks:
+        return Decimal("0")
+
+    best_bid = Decimal(str(bids[0]["price"]))
+    best_ask = Decimal(str(asks[0]["price"]))
+    if best_bid <= best_ask:
+        return Decimal("0")
+
+    return best_bid - best_ask
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,44 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+
+def import_place_order(monkeypatch):
+    dummy = types.ModuleType("paradex_py")
+    dummy_paradex = types.ModuleType("paradex_py.paradex")
+    dummy_common = types.ModuleType("paradex_py.common")
+    dummy_order = types.ModuleType("paradex_py.common.order")
+    dummy_paradex.Paradex = object
+    dummy_order.Order = object
+    dummy_order.OrderSide = object
+    dummy_order.OrderType = object
+    monkeypatch.setitem(sys.modules, "paradex_py", dummy)
+    monkeypatch.setitem(sys.modules, "paradex_py.paradex", dummy_paradex)
+    monkeypatch.setitem(sys.modules, "paradex_py.common", dummy_common)
+    monkeypatch.setitem(sys.modules, "paradex_py.common.order", dummy_order)
+    return importlib.import_module("place_order")
+
+
+def test_load_config_from_env(monkeypatch):
+    place_order = import_place_order(monkeypatch)
+    monkeypatch.setenv("PARADEX_L1_ADDRESS", "0xabc")
+    monkeypatch.setenv("PARADEX_L1_PRIVATE_KEY", "key")
+    monkeypatch.setenv("PARADEX_ENV", "mainnet")
+
+    importlib.reload(place_order)
+    cfg = place_order.load_config()
+    assert cfg["env"] == "mainnet"
+    assert cfg["l1_address"] == "0xabc"
+    assert cfg["l1_private_key"] == "key"
+
+
+def test_load_config_missing_required(monkeypatch):
+    place_order = import_place_order(monkeypatch)
+    monkeypatch.delenv("PARADEX_L1_ADDRESS", raising=False)
+    monkeypatch.setenv("PARADEX_L1_PRIVATE_KEY", "key")
+    importlib.reload(place_order)
+    with pytest.raises(SystemExit):
+        place_order.load_config()
+

--- a/tests/test_inversion.py
+++ b/tests/test_inversion.py
@@ -1,0 +1,24 @@
+from decimal import Decimal
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from market_utils import check_inversion
+
+
+def test_check_inversion_profit():
+    book = {
+        "bids": [{"price": "101"}],
+        "asks": [{"price": "100"}],
+    }
+    assert check_inversion(book) == Decimal("1")
+
+
+def test_check_inversion_no_profit():
+    book = {
+        "bids": [{"price": "99"}],
+        "asks": [{"price": "100"}],
+    }
+    assert check_inversion(book) == Decimal("0")
+


### PR DESCRIPTION
## Summary
- create a simple `check_inversion` helper
- introduce pytest suite for config loading and inversion logic
- document how to run the tests and add CI workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854032dd54c8331a83ef60b0d33f4ff