### PR TITLE
Shorten order book refresh interval

### DIFF
--- a/arbitrage_bot.py
+++ b/arbitrage_bot.py
@@ -182,7 +182,7 @@ class ArbitrageBot:
         await self.paradex.ws_client.subscribe(
             ParadexWebsocketChannel.ORDER_BOOK,
             self.on_order_book,
-            params={"market": self.cfg["market"], "price_tick": "l2", "refresh_rate": "100ms"},
+            params={"market": self.cfg["market"], "price_tick": "l2", "refresh_rate": "50ms"},
         )
         await self.paradex.ws_client.subscribe(
             ParadexWebsocketChannel.ACCOUNT,


### PR DESCRIPTION
## Summary
- reduce order book WebSocket `refresh_rate` from 100ms to 50ms

## Testing
- `python -m py_compile arbitrage_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68540581a1ec83318ca457de3e4ae65f