### PR TITLE
Use thread for account summary

### DIFF
--- a/arbitrage_bot.py
+++ b/arbitrage_bot.py
@@ -85,7 +85,9 @@ class ArbitrageBot:
         self.open_batches: Dict[str, Dict[str, str]] = {}
 
     async def refresh_balance(self) -> None:
-        summary = self.paradex.api_client.fetch_account_summary()
+        summary = await asyncio.to_thread(
+            self.paradex.api_client.fetch_account_summary
+        )
         if getattr(summary, "free_collateral", None):
             self.available_balance_usd = Decimal(summary.free_collateral)
         self.logger.debug("Balance refreshed: %s", self.available_balance_usd)


### PR DESCRIPTION
## Summary
- call `fetch_account_summary` using `asyncio.to_thread`
- keep periodic balance refresher awaiting the async function

## Testing
- `python -m py_compile *.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685416c5b3348331bae8d2724e75bc97