### PR TITLE
Remove verbose order book logging

### DIFF
--- a/arbitrage_bot.py
+++ b/arbitrage_bot.py
@@ -116,7 +116,8 @@ class ArbitrageBot:
                 self.logger.info("Order %s %s", client_id, status)
 
     async def on_order_book(self, _channel, message) -> None:
-        self.logger.debug("Order book message: %s", message)
+        # Avoid logging the entire order book message to prevent flooding the
+        # terminal. The data is still processed below.
         data = message.get("params", {}).get("data", {})
         bids = data.get("bids")
         asks = data.get("asks")


### PR DESCRIPTION
## Summary
- avoid printing entire order book array in `arbitrage_bot`

## Testing
- `python -m py_compile arbitrage_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_6854761b7c408331a494e1aeb3ea03d8