### PR TITLE
Fix order init params

### DIFF
--- a/arbitrage_bot.py
+++ b/arbitrage_bot.py
@@ -237,7 +237,7 @@ class ArbitrageBot:
                 size=size,
                 limit_price=price_buy,
                 client_id=f"{batch_id}-buy",
-                time_in_force="GTC",
+                instruction="GTC",
             ),
             Order(
                 market=self.cfg["market"],
@@ -246,7 +246,7 @@ class ArbitrageBot:
                 size=size,
                 limit_price=price_sell,
                 client_id=f"{batch_id}-sell",
-                post_only=True,
+                instruction="POST_ONLY",
             ),
         ]
         try:


### PR DESCRIPTION
## Summary
- adjust parameters when creating orders

## Testing
- `python -m py_compile arbitrage_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_685541b73e908331b6c9f06567c71dd5