### PR TITLE
Remove POST-ONLY flag

### DIFF
--- a/arbitrage_bot.py
+++ b/arbitrage_bot.py
@@ -251,7 +251,7 @@ class ArbitrageBot:
                 size=size,
                 limit_price=price_sell,
                 client_id=f"{batch_id}-sell",
-                instruction="POST_ONLY",
+                instruction="GTC",
             ),
         ]
         try:


### PR DESCRIPTION
## Summary
- allow sell orders to execute by dropping POST-ONLY

## Testing
- `python -m py_compile arbitrage_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_68554d70d49483318d7c054c2d827fa8