### PR TITLE
Remove redundant position refreshes

### DIFF
--- a/arbitrage_bot.py
+++ b/arbitrage_bot.py
@@ -193,7 +193,6 @@ class ArbitrageBot:
             return
         if self.best_bid_qty is None or self.best_ask_qty is None:
             return
-        await self.refresh_positions()
         if self.has_open_position:
             self.logger.info("Open position detected, skipping new orders")
             return
@@ -260,7 +259,6 @@ class ArbitrageBot:
 
     async def handle_order(self, price_buy: Decimal, price_sell: Decimal, size: Decimal) -> None:
         await self.refresh_balance()
-        await self.refresh_positions()
         if self.has_open_position:
             self.logger.info("Open position detected, skipping new orders")
             return


### PR DESCRIPTION
## Summary
- rely on balance refresher and websocket updates to keep positions in sync
- remove direct position refresh from `check_inversion` and `handle_order`

## Testing
- `python -m py_compile arbitrage_bot.py async_bot.py place_order.py paradex_bot.py`

------
https://chatgpt.com/codex/tasks/task_e_685567bb31908331808905444ef43200