### PR TITLE
Fix async batch order submission

### DIFF
--- a/arbitrage_bot.py
+++ b/arbitrage_bot.py
@@ -301,7 +301,9 @@ class ArbitrageBot:
             ),
         ]
         try:
-            self.paradex.api_client.submit_orders_batch(orders)
+            await asyncio.to_thread(
+                self.paradex.api_client.submit_orders_batch, orders
+            )
             self.open_batches[batch_id] = {"buy": orders[0].client_id, "sell": orders[1].client_id}
             self.logger.info(
                 "\u0420\u0430\u0437\u043c\u0435\u0449\u0435\u043d\u044b \u043e\u0440\u0434\u0435\u0440\u0430: BUY %s @ %s \u2192 SELL @ %s",


### PR DESCRIPTION
## Summary
- wrap blocking `submit_orders_batch` call in `asyncio.to_thread`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68556838028883318bebe955d99aef4e