### PR TITLE
Remove losing trade restriction

### DIFF
--- a/arbitrage_bot.py
+++ b/arbitrage_bot.py
@@ -215,9 +215,6 @@ class ArbitrageBot:
             else:
                 self.logger.info("Open position detected, skipping new orders")
             return
-        if self.last_position_pnl is not None and self.last_position_pnl <= 0:
-            self.logger.info("Previous position closed without profit")
-            return
         order_size = min(self.best_bid_qty, self.best_ask_qty)
         if "order_size" in self.cfg:
             order_size = min(order_size, self.cfg["order_size"])
@@ -286,9 +283,6 @@ class ArbitrageBot:
                 )
             else:
                 self.logger.info("Open position detected, skipping new orders")
-            return
-        if self.last_position_pnl is not None and self.last_position_pnl <= 0:
-            self.logger.info("Previous position closed without profit")
             return
         if "order_size" in self.cfg:
             size = min(size, self.cfg["order_size"])

--- a/tests/test_arbitrage_bot.py
+++ b/tests/test_arbitrage_bot.py
@@ -79,4 +79,4 @@ async def test_check_inversion_closed_negative(bot, monkeypatch):
     positions = {"results": [{"market": "ETH-USD-PERP", "status": "CLOSED", "closed_at": 1, "realized_positional_pnl": "-1"}]}
     placed = await prepare_bot(bot, positions, monkeypatch)
     await bot.check_inversion()
-    assert not placed
+    assert placed


### PR DESCRIPTION
## Summary
- allow arbitrage bot to place orders after a loss
- adjust tests for new behaviour

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68556d2336c083319b251b452f91b1a6