### PR TITLE
Add order book inversion scanning

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ PARADEX_L1_PRIVATE_KEY=...
 # or alternatively
 PARADEX_L2_PRIVATE_KEY=...
 PARADEX_LEVERAGE=30            # optional leverage for arbitrage_bot
+PARADEX_MIN_PROFIT=1           # minimum price difference for arbitrage
 ```
 
 ### Install dependencies

--- a/tests/test_arbitrage_bot.py
+++ b/tests/test_arbitrage_bot.py
@@ -163,3 +163,22 @@ async def test_check_inversion_short_direction(bot, monkeypatch):
     bot.cfg["maker_fee_pct"] = Decimal("0.0002")
     await bot.check_inversion()
     assert placed["order"][3] == "short"
+
+
+def test_scan_full_book(monkeypatch, bot):
+    captured = {}
+
+    async def fake_handle(self, ask_price, bid_price, size, direction="long"):
+        captured["order"] = (ask_price, bid_price, size, direction)
+
+    monkeypatch.setattr(bot, "handle_order", fake_handle.__get__(bot))
+    bot.cfg["min_profit"] = Decimal("1")
+    bids = [["102", "1"], ["101", "1"]]
+    asks = [["100", "1"], ["99", "1"]]
+    asyncio.run(bot.scan_full_book(bids, asks))
+    assert captured["order"] == (
+        Decimal("100"),
+        Decimal("102"),
+        Decimal("1"),
+        "long",
+    )


### PR DESCRIPTION
## Summary
- scan full order book for price inversions
- configure `PARADEX_MIN_PROFIT` threshold
- document new env variable
- test new scanning logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68559efb33fc8331a2ab19ce974208df