### PR TITLE
Adjust short order args

### DIFF
--- a/arbitrage_bot.py
+++ b/arbitrage_bot.py
@@ -251,7 +251,14 @@ class ArbitrageBot:
                     await self.handle_order(ask_price, bid_price, size, "long")
                     return
                 elif ask_price >= bid_price + min_profit and profit_short_ok:
-                    await self.handle_order(bid_price, ask_price, size, "short")
+                    lower_bid = bid_price
+                    higher_ask = ask_price
+                    await self.handle_order(
+                        price_buy=lower_bid,
+                        price_sell=higher_ask,
+                        size=size,
+                        direction="short",
+                    )
                     return
 
     async def check_inversion(self) -> None:
@@ -364,7 +371,17 @@ class ArbitrageBot:
             f"\u2192 {'SELL' if direction=='long' else 'BUY'}@{price_sell if direction=='long' else price_buy}  \u0394={price_sell - price_buy:.2f}  Net={net:.2f}"
         )
         print(signal)
-        await self.handle_order(price_buy, price_sell, q1, direction)
+        if direction == "short":
+            lower_bid = price_buy
+            higher_ask = price_sell
+            await self.handle_order(
+                price_buy=lower_bid,
+                price_sell=higher_ask,
+                size=q1,
+                direction=direction,
+            )
+        else:
+            await self.handle_order(price_buy, price_sell, q1, direction)
 
     async def handle_order(
         self, price_buy: Decimal, price_sell: Decimal, size: Decimal, direction: str = "long"

--- a/tests/test_arbitrage_bot.py
+++ b/tests/test_arbitrage_bot.py
@@ -86,7 +86,11 @@ async def test_check_inversion_closed_negative(bot, monkeypatch):
 async def test_scan_inversions_buy_sell(bot, monkeypatch):
     captured = {}
 
-    async def fake_handle(self, pb, ps, q, direction="long"):
+    async def fake_handle(self, *args, **kwargs):
+        pb = kwargs.get("price_buy", args[0] if len(args) > 0 else None)
+        ps = kwargs.get("price_sell", args[1] if len(args) > 1 else None)
+        q = kwargs.get("size", args[2] if len(args) > 2 else None)
+        direction = kwargs.get("direction", args[3] if len(args) > 3 else "long")
         captured["order"] = (pb, ps, q, direction)
 
     monkeypatch.setattr(bot, "handle_order", fake_handle.__get__(bot))
@@ -107,7 +111,11 @@ async def test_scan_inversions_buy_sell(bot, monkeypatch):
 async def test_scan_inversions_sell_buy(bot, monkeypatch):
     captured = {}
 
-    async def fake_handle(self, pb, ps, q, direction="long"):
+    async def fake_handle(self, *args, **kwargs):
+        pb = kwargs.get("price_buy", args[0] if len(args) > 0 else None)
+        ps = kwargs.get("price_sell", args[1] if len(args) > 1 else None)
+        q = kwargs.get("size", args[2] if len(args) > 2 else None)
+        direction = kwargs.get("direction", args[3] if len(args) > 3 else "long")
         captured["order"] = (pb, ps, q, direction)
 
     monkeypatch.setattr(bot, "handle_order", fake_handle.__get__(bot))
@@ -128,7 +136,11 @@ async def test_scan_inversions_sell_buy(bot, monkeypatch):
 async def test_scan_inversions_zero_delta(bot, monkeypatch):
     captured = {}
 
-    async def fake_handle(self, pb, ps, q, direction="long"):
+    async def fake_handle(self, *args, **kwargs):
+        pb = kwargs.get("price_buy", args[0] if len(args) > 0 else None)
+        ps = kwargs.get("price_sell", args[1] if len(args) > 1 else None)
+        q = kwargs.get("size", args[2] if len(args) > 2 else None)
+        direction = kwargs.get("direction", args[3] if len(args) > 3 else "long")
         captured["order"] = (pb, ps, q, direction)
 
     monkeypatch.setattr(bot, "handle_order", fake_handle.__get__(bot))
@@ -144,7 +156,11 @@ async def test_scan_inversions_zero_delta(bot, monkeypatch):
 async def test_scan_inversions_size_mismatch(bot, monkeypatch):
     captured = {}
 
-    async def fake_handle(self, pb, ps, q, direction="long"):
+    async def fake_handle(self, *args, **kwargs):
+        pb = kwargs.get("price_buy", args[0] if len(args) > 0 else None)
+        ps = kwargs.get("price_sell", args[1] if len(args) > 1 else None)
+        q = kwargs.get("size", args[2] if len(args) > 2 else None)
+        direction = kwargs.get("direction", args[3] if len(args) > 3 else "long")
         captured["order"] = (pb, ps, q, direction)
 
     monkeypatch.setattr(bot, "handle_order", fake_handle.__get__(bot))
@@ -168,7 +184,11 @@ async def test_check_inversion_short_direction(bot, monkeypatch):
 def test_scan_full_book(monkeypatch, bot):
     captured = {}
 
-    async def fake_handle(self, pb, ps, size, direction="long"):
+    async def fake_handle(self, *args, **kwargs):
+        pb = kwargs.get("price_buy", args[0] if len(args) > 0 else None)
+        ps = kwargs.get("price_sell", args[1] if len(args) > 1 else None)
+        size = kwargs.get("size", args[2] if len(args) > 2 else None)
+        direction = kwargs.get("direction", args[3] if len(args) > 3 else "long")
         captured["order"] = (pb, ps, size, direction)
 
     monkeypatch.setattr(bot, "handle_order", fake_handle.__get__(bot))
@@ -187,7 +207,11 @@ def test_scan_full_book(monkeypatch, bot):
 def test_scan_full_book_short(monkeypatch, bot):
     captured = {}
 
-    async def fake_handle(self, pb, ps, size, direction="long"):
+    async def fake_handle(self, *args, **kwargs):
+        pb = kwargs.get("price_buy", args[0] if len(args) > 0 else None)
+        ps = kwargs.get("price_sell", args[1] if len(args) > 1 else None)
+        size = kwargs.get("size", args[2] if len(args) > 2 else None)
+        direction = kwargs.get("direction", args[3] if len(args) > 3 else "long")
         captured["order"] = (pb, ps, size, direction)
 
     monkeypatch.setattr(bot, "handle_order", fake_handle.__get__(bot))
@@ -206,7 +230,11 @@ def test_scan_full_book_short(monkeypatch, bot):
 def test_scan_full_book_profit_filter(monkeypatch, bot):
     captured = {}
 
-    async def fake_handle(self, pb, ps, size, direction="long"):
+    async def fake_handle(self, *args, **kwargs):
+        pb = kwargs.get("price_buy", args[0] if len(args) > 0 else None)
+        ps = kwargs.get("price_sell", args[1] if len(args) > 1 else None)
+        size = kwargs.get("size", args[2] if len(args) > 2 else None)
+        direction = kwargs.get("direction", args[3] if len(args) > 3 else "long")
         captured["order"] = (pb, ps, size, direction)
 
     monkeypatch.setattr(bot, "handle_order", fake_handle.__get__(bot))


### PR DESCRIPTION
## Summary
- ensure short trades pass lower bid and higher ask to `handle_order`
- update tests to support keyword arguments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855b37b14848331baf291c95555999e