### PR TITLE
Fix short price order in check_inversion

### DIFF
--- a/arbitrage_bot.py
+++ b/arbitrage_bot.py
@@ -317,7 +317,10 @@ class ArbitrageBot:
             self.logger.warning("Max open orders reached")
             return
         self.logger.info("\u0420\u0430\u0437\u043c\u0435\u0449\u0430\u044e \u043e\u0440\u0434\u0435\u0440\u0430")
-        await self.place_orders(self.best_ask, self.best_bid, order_size, direction)
+        if direction == "short":
+            await self.place_orders(self.best_bid, self.best_ask, order_size, direction)
+        else:
+            await self.place_orders(self.best_ask, self.best_bid, order_size, direction)
 
     async def scan_inversions(self, inserts) -> None:
         """Check for simple two-order cross spreads regardless of order."""

--- a/tests/test_arbitrage_bot.py
+++ b/tests/test_arbitrage_bot.py
@@ -184,7 +184,12 @@ async def test_check_inversion_short_direction(bot, monkeypatch):
     bot.cfg["taker_fee_pct"] = Decimal("0.0001")
     bot.cfg["maker_fee_pct"] = Decimal("0.0002")
     await bot.check_inversion()
-    assert placed["order"][3] == "short"
+    assert placed["order"] == (
+        Decimal("100"),
+        Decimal("90"),
+        Decimal("1"),
+        "short",
+    )
 
 
 def test_scan_full_book(monkeypatch, bot):


### PR DESCRIPTION
## Summary
- fix the order of prices when placing short orders
- verify the short scenario price order in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ba782af48331b5922443289427c9