### PR TITLE
Remove redundant refresh_positions in handle_order

### DIFF
--- a/arbitrage_bot.py
+++ b/arbitrage_bot.py
@@ -389,7 +389,6 @@ class ArbitrageBot:
         self, price_buy: Decimal, price_sell: Decimal, size: Decimal, direction: str = "long"
     ) -> None:
         await self.refresh_balance()
-        await self.refresh_positions()
         if self.has_open_position:
             if self.open_position_price is not None:
                 self.logger.info(


### PR DESCRIPTION
## Summary
- avoid unnecessary REST call when handling orders

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855bc216c008331b0da434e1702b322